### PR TITLE
feat: Update Testimonials.svelte to link to recent stateofjs report

### DIFF
--- a/apps/svelte.dev/src/routes/_home/Testimonials.svelte
+++ b/apps/svelte.dev/src/routes/_home/Testimonials.svelte
@@ -34,7 +34,7 @@
 			></enhanced:img>
 		</a>
 
-		<a href="https://2023.stateofjs.com/en-US/libraries/front-end-frameworks/">
+		<a href="https://2024.stateofjs.com/en-US/libraries/front-end-frameworks/">
 			<enhanced:img
 				class="screenshot"
 				alt="State of JavaScript 2023"


### PR DESCRIPTION
Update Testimonials.svelte to link to recent stateofjs report from 2024 instead of 2023